### PR TITLE
Add `!upload_image` WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,3 +339,7 @@ Change to the Scene where you can read code.
 ### Questions
 
 - How does scroll stop???
+
+## Remove BG
+
+- [rembg](https://github.com/danielgatis/rembg) and available on the PATH

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,40 @@
+pub fn upload_image(msg: UserMessage) -> Result<()> {
+    let image_url = msg
+        .contents
+        .iter()
+        .split(" ")
+        .skip(1)
+        .take(1)
+        .collect::<Vec<String>>();
+
+    let output_path = format!("{}.png" msg.user_name);
+
+    let output = Command::new("sh")
+        .arg(format!("curl -s {} | rembg i > output.png", image_url))
+        .output()
+        .expect("failed to executge process");
+
+    let output = Command::new("sh")
+        .arg(format!(
+            "convert output.png -resize 256x256^ {}",
+            output_path
+        ))
+        .output()
+        .expect("failed to edcute proces");
+
+    Ok(())
+}
+
+mod tests {
+    use subd_types::UserMessage;
+
+    fn upload_image() {
+        super::handlers::upload_image(UserMessage {
+            user_id: 1,
+            user_name: "rockerBOO".to_string(),
+            roles: subd_types::Role::TwitchMod,
+            platform: subd_types::UserPlatform::Twitch,
+            contents: "hello test chat".to_string(),
+        })
+    }
+}

--- a/src/obs_routing.rs
+++ b/src/obs_routing.rs
@@ -116,6 +116,9 @@ pub async fn handle_obs_commands(
             Ok(())
         }
 
+        // !upload_image URL 
+        "!upload_image" => handlers::upload_image(msg),
+
         // ===========================================
         // == Scrolling
         // ===========================================


### PR DESCRIPTION
*Note:* this should work, but I couldn't get postgres working, so couldn't compile. Also, possible security issues since it downloads the file (with curl) right into a python script (rembg). 

`!upload_image URL` will download the image, remove the background, and resize into a 256x256 image size (by the largest dimension, and keeping the aspect ratio).

Needs
- curl
- [rembg](https://github.com/danielgatis/rembg) in your path
- imagemagick (convert)

```
curl -s {} | rembg i > output.png
convert output.png -resize 256x256^ {}
```